### PR TITLE
add jpa block to default profile

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,6 +104,14 @@ scheduler:
       subject: scheduler@scheduler.cgi.com
       token-validity: 1600000
       secret: ${API_JOB_EXECUTION_SERVICE_AUTHENTICATION_SECRET}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    generate-ddl: true
+  quartz:
+    jdbc:
+      initialize-schema: always
 ---
 spring:
   config:


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###
As we are not running flyway yet in JCDE, need to add jpa block to default profile in order for tables to be created on startup


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
