### PR TITLE
Scheduler jobs are disabled when a code deployment occurs

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/scheduler/service/impl/SchedulerServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/scheduler/service/impl/SchedulerServiceImpl.java
@@ -17,6 +17,7 @@ import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.juror.scheduler.datastore.entity.api.APIJobDetailsEntity;
 import uk.gov.hmcts.juror.scheduler.datastore.model.JobType;
 import uk.gov.hmcts.juror.scheduler.service.contracts.SchedulerService;
@@ -56,6 +57,7 @@ public class SchedulerServiceImpl implements SchedulerService {
     }
 
     @Override
+    @Transactional
     public void register(APIJobDetailsEntity jobDetails) {
         if (jobDetails.getCronExpression() != null) {
             scheduleCronJob(jobDetails);
@@ -130,6 +132,7 @@ public class SchedulerServiceImpl implements SchedulerService {
     }
 
     @Override
+    @Transactional
     public void unregister(String jobKey) {
         try {
             scheduler.deleteJob(createJobKey(jobKey));


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7593)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=205)


### Change description ###
Ben has observed that when a deployment is made to DEMO, the jobs which had been enabled are set to disabled. We tested this with today’s deployment to DEMO, setting POOL_TRANSFER to “enabled”: true. After the deploy, the job has been set to “enabled”: false.

!image-20240618-142410.png|width=1812,height=1018,alt="image-20240618-142410.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
