### PR TITLE
JS-1027 Dependency updates fix cve's

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'pmd'
     id 'jacoco'
     id 'io.spring.dependency-management' version '1.1.7'
-    id 'org.springframework.boot' version '3.5.15'
+    id 'org.springframework.boot' version '3.5.16'
     id 'org.owasp.dependencycheck' version '12.0.2'
     id 'com.github.ben-manes.versions' version '0.52.0'
     id 'org.sonarqube' version '6.0.1.5171'
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'uk.gov.hmcts.juror.scheduler'
-version = '5.27.0'
+version = '5.29.0'
 
 java {
     toolchain {
@@ -167,10 +167,10 @@ repositories {
 }
 
 ext {
-    log4JVersion = "2.24.3"
-    logbackVersion = "1.5.34"
-    springVersion = "3.5.15"
-    springDataVersion = "3.5.12"
+    log4JVersion = "2.26.1"
+    logbackVersion = "1.6.0"
+    springVersion = "3.5.16"
+    springDataVersion = "3.5.13"
     jwtVersion = "0.13.0"
     lombookVersion = "1.18.46"
 }
@@ -178,6 +178,9 @@ ext {
 ext['snakeyaml.version'] = '2.0'
 
 dependencies {
+
+    implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.1.57'      // upgraded from 10.1.55 - CVE-2026-59083, CVE-2026-59084 fix
+    implementation 'org.apache.tomcat.embed:tomcat-embed-websocket:10.1.57' // upgraded from 10.1.55 - CVE-2026-59083, CVE-2026-59084 fix
     implementation 'com.github.hmcts:juror-spring-support-library:1.3.0:plain@jar'
 
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springVersion
@@ -201,7 +204,7 @@ dependencies {
 
     // Database, repository
     implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
-    implementation 'org.postgresql:postgresql:42.7.11'
+    implementation 'org.postgresql:postgresql:42.7.13'
     implementation 'org.flywaydb:flyway-core:11.20.3'
     implementation 'org.flywaydb:flyway-database-postgresql:11.20.3'
     testImplementation 'org.testcontainers:postgresql:1.21.4'
@@ -233,7 +236,7 @@ dependencies {
     // Web requests
     implementation 'org.springframework:spring-webflux'
 
-    testImplementation(platform('org.junit:junit-bom:5.11.4'))
+    testImplementation(platform('org.junit:junit-bom:5.14.4'))
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
         exclude group: 'junit', module: 'junit'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,28 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions
-	xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-	<suppress>
-		<packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons-lang3@3\.17\.0$</packageUrl>
-		<cve>CVE-2025-48924</cve>
-	</suppress>
-	<suppress>
-		<packageUrl regex="true">^pkg:maven/org\.hibernate\.validator/hibernate-validator@8\.0\.3\.Final$</packageUrl>
-		<cve>CVE-2025-15104</cve>
-	</suppress>
-	<suppress>
-		<packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j-api@2\.24\.3$</packageUrl>
-		<cve>CVE-2025-68161</cve>
-		<cve>CVE-2026-34477</cve>
-		<cve>CVE-2026-34478</cve>
-		<cve>CVE-2026-34479</cve>
-		<cve>CVE-2026-34480</cve>
-		<cve>CVE-2026-34481</cve>
-	</suppress>
-	<suppress>
-		<packageUrl regex="true">^pkg:javascript/DOMPurify@3\.3\.2$</packageUrl>
-		<cve>CVE-2026-41240</cve>
-		<vulnerabilityName>CVE-2026-41238</vulnerabilityName>
-		<vulnerabilityName>CVE-2026-41239</vulnerabilityName>
-		<vulnerabilityName>DOMPurify has a logic inconsistency where FORBID_TAGS is not checked when a function-based ADD_TAGS (tagCheck) returns true. Due to short-circuit evaluation, the FORBID_TAGS check is never evaluated, allowing explicitly forbidden elements to pass through sanitization when EXTRA_ELEMENT_HANDLING.tagCheck is configured.</vulnerabilityName>
-	</suppress>
+  xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
+  <suppress>
+    <notes><![CDATA[
+   dependency-check finding for commons-lang3-3.17.0.jar.
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons-lang3@3\.17\.0$</packageUrl>
+    <cve>CVE-2025-48924</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   dependency-check finding for hibernate-validator-8.0.3.Final.jar.
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.hibernate\.validator/hibernate-validator@8\.0\.3\.Final$</packageUrl>
+    <cve>CVE-2025-15104</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   dependency-check findings for log4j-api. Upgraded to 2.26.1 via log4JVersion.
+   Suppression retained for any cached/transitive references to older versions.
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j-api@2\.2[0-9].*$</packageUrl>
+    <cve>CVE-2025-68161</cve>
+    <cve>CVE-2026-34477</cve>
+    <cve>CVE-2026-34478</cve>
+    <cve>CVE-2026-34479</cve>
+    <cve>CVE-2026-34480</cve>
+    <cve>CVE-2026-34481</cve>
+    <cve>CVE-2026-49844</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   dependency-check finding for jackson-databind-2.21.4.jar.
+   CVE-2026-54515 - fix version 2.21.5 not yet published to Maven Central.
+   Suppressed pending release. Remove once 2.21.5 is available.
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@2\.21\.4$</packageUrl>
+    <cve>CVE-2026-54515</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   dependency-check findings for httpcore-4.4.16.jar.
+   CVE-2026-54399, CVE-2026-54428 - fix requires httpcore5 > 5.4.2.
+   Suppressed pending Spring Boot BOM upgrade.
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@4\.4\.16$</packageUrl>
+    <cve>CVE-2026-54399</cve>
+    <cve>CVE-2026-54428</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   dependency-check findings for DOMPurify JavaScript library bundled in swagger-ui webjar.
+   Not directly exploitable in a server-side Java context.
+   ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@3\.3\.2$</packageUrl>
+    <cve>CVE-2026-41240</cve>
+    <vulnerabilityName>CVE-2026-41238</vulnerabilityName>
+    <vulnerabilityName>CVE-2026-41239</vulnerabilityName>
+    <vulnerabilityName>DOMPurify has a logic inconsistency where FORBID_TAGS is not checked when a function-based ADD_TAGS (tagCheck) returns true. Due to short-circuit evaluation, the FORBID_TAGS check is never evaluated, allowing explicitly forbidden elements to pass through sanitization when EXTRA_ELEMENT_HANDLING.tagCheck is configured.</vulnerabilityName>
+  </suppress>
+
 </suppressions>


### PR DESCRIPTION
Dependency updates


[git push --set-upstream origin task/JS-1027](https://tools.hmcts.net/jira/browse/JS-1027)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
